### PR TITLE
Relax `bytestring` upper bound and bump to Stackage LTS-18.28

### DIFF
--- a/crc32c.cabal
+++ b/crc32c.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.1.
+-- This file has been generated from package.yaml by hpack version 0.35.1.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 90e286fde5d013c853cdb6ad9ef6c03ad8eea828fa98d136baf253d357d78dee
+-- hash: fe47bbeb2914ae1fb46b4501e79c904eb440718d97bb1ac42f368184dc7dae2d
 
 name:           crc32c
 version:        0.0.0
@@ -51,7 +51,8 @@ library
       c2hs
   build-depends:
       base >=4.9 && <5
-    , bytestring >=0.10.8.2 && <0.11
+    , bytestring >=0.10.8.2
+  default-language: Haskell2010
   if arch(x86_64)
     cc-options: -std=c++11 -D__HAVE_SSE42=1 -D__HAVE_ARM64_CRC32C=0 -msse4.2
   else
@@ -59,7 +60,6 @@ library
       cc-options: -std=c++11 -D__HAVE_SSE42=0 -D__HAVE_ARM64_CRC32C=1
     else
       cc-options: -std=c++11 -D__HAVE_SSE42=0 -D__HAVE_ARM64_CRC32C=0
-  default-language: Haskell2010
 
 test-suite crc32c-test
   type: exitcode-stdio-1.0

--- a/package.yaml
+++ b/package.yaml
@@ -24,7 +24,7 @@ library:
   source-dirs: src
   dependencies:
   - base >= 4.9 && < 5
-  - bytestring >=0.10.8.2 && <0.11
+  - bytestring >=0.10.8.2
   include-dirs: 
   - include
   c-sources:

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-13.20
+resolver: lts-18.28
 packages:
 - .


### PR DESCRIPTION
This PR has just minor constraint changes in order to render it more compatible with newer Haskell projects.