### PR TITLE
Update vendored crc32c code

### DIFF
--- a/crc32c.cabal
+++ b/crc32c.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: cb900d1f534e3f24ee23198d420b74ded026c6b1b6c69a70ca685d93c7930def
+-- hash: aefc1f6fcf279fc7fb1d71bcf79f62a3334fa0e3f43501844ed6bb3ec3cfbbae
 
 name:           crc32c
-version:        0.2.0.0
+version:        0.2.0
 synopsis:       Haskell bindings for crc32c
 category:       FFI, Raw
 homepage:       https://github.com/leptonyu/crc32c#readme

--- a/crc32c.cabal
+++ b/crc32c.cabal
@@ -4,10 +4,10 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f7f2cd11c393ed93e85bacd809cead2af472e29e17cfcab27aa36cf45ce7e11c
+-- hash: cb900d1f534e3f24ee23198d420b74ded026c6b1b6c69a70ca685d93c7930def
 
 name:           crc32c
-version:        0.1.0
+version:        0.2.0.0
 synopsis:       Haskell bindings for crc32c
 category:       FFI, Raw
 homepage:       https://github.com/leptonyu/crc32c#readme
@@ -21,7 +21,7 @@ extra-source-files:
     README.md
     include/LICENSE
     include/crc32c_arm64.h
-    include/crc32c_arm64_linux_check.h
+    include/crc32c_arm64_check.h
     include/crc32c_internal.h
     include/crc32c_prefetch.h
     include/crc32c_read_le.h

--- a/crc32c.cabal
+++ b/crc32c.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 1a4d90d4e9381a7e6ebad0ead5753fb5d408d10dca3875cc575fa3b9a83becbc
+-- hash: f7f2cd11c393ed93e85bacd809cead2af472e29e17cfcab27aa36cf45ce7e11c
 
 name:           crc32c
 version:        0.1.0
@@ -71,7 +71,7 @@ test-suite crc32c-test
   build-depends:
       QuickCheck
     , base >=4.9 && <5
-    , bytestring >=0.10.8.2 && <0.11
+    , bytestring >=0.10.8.2 && <0.12
     , crc32c
     , hspec
     , hspec-core

--- a/include/crc32c.cc
+++ b/include/crc32c.cc
@@ -8,7 +8,7 @@
 #include <cstdint>
 
 #include "./crc32c_arm64.h"
-#include "./crc32c_arm64_linux_check.h"
+#include "./crc32c_arm64_check.h"
 #include "./crc32c_internal.h"
 #include "./crc32c_sse42.h"
 #include "./crc32c_sse42_check.h"
@@ -20,8 +20,8 @@ uint32_t Extend(uint32_t crc, const uint8_t* data, size_t count) {
   static bool can_use_sse42 = CanUseSse42();
   if (can_use_sse42) return ExtendSse42(crc, data, count);
 #elif HAVE_ARM64_CRC32C
-  static bool can_use_arm_linux = CanUseArm64Linux();
-  if (can_use_arm_linux) return ExtendArm64(crc, data, count);
+  static bool can_use_arm64_crc32 = CanUseArm64Crc32();
+  if (can_use_arm64_crc32) return ExtendArm64(crc, data, count);
 #endif  // HAVE_SSE42 && (defined(_M_X64) || defined(__x86_64__))
 
   return ExtendPortable(crc, data, count);

--- a/include/crc32c_arm64.cc
+++ b/include/crc32c_arm64.cc
@@ -62,7 +62,7 @@
 
 namespace crc32c {
 
-uint32_t ExtendArm64(uint32_t crc, const uint8_t *buf, size_t size) {
+uint32_t ExtendArm64(uint32_t crc, const uint8_t *data, size_t size) {
   int64_t length = size;
   uint32_t crc0, crc1, crc2, crc3;
   uint64_t t0, t1, t2;
@@ -72,7 +72,6 @@ uint32_t ExtendArm64(uint32_t crc, const uint8_t *buf, size_t size) {
   const poly64_t k0 = 0x8d96551c, k1 = 0xbd6f81f8, k2 = 0xdcb17aa4;
 
   crc = crc ^ kCRC32Xor;
-  const uint8_t *p = reinterpret_cast<const uint8_t *>(buf);
 
   while (length >= KBYTES) {
     crc0 = crc;
@@ -81,14 +80,14 @@ uint32_t ExtendArm64(uint32_t crc, const uint8_t *buf, size_t size) {
     crc3 = 0;
 
     // Process 1024 bytes in parallel.
-    CRC32C1024BYTES(p);
+    CRC32C1024BYTES(data);
 
     // Merge the 4 partial CRC32C values.
     t2 = (uint64_t)vmull_p64(crc2, k2);
     t1 = (uint64_t)vmull_p64(crc1, k1);
     t0 = (uint64_t)vmull_p64(crc0, k0);
-    crc = __crc32cd(crc3, *(uint64_t *)p);
-    p += sizeof(uint64_t);
+    crc = __crc32cd(crc3, *(uint64_t *)data);
+    data += sizeof(uint64_t);
     crc ^= __crc32cd(0, t2);
     crc ^= __crc32cd(0, t1);
     crc ^= __crc32cd(0, t0);
@@ -97,23 +96,23 @@ uint32_t ExtendArm64(uint32_t crc, const uint8_t *buf, size_t size) {
   }
 
   while (length >= 8) {
-    crc = __crc32cd(crc, *(uint64_t *)p);
-    p += 8;
+    crc = __crc32cd(crc, *(uint64_t *)data);
+    data += 8;
     length -= 8;
   }
 
   if (length & 4) {
-    crc = __crc32cw(crc, *(uint32_t *)p);
-    p += 4;
+    crc = __crc32cw(crc, *(uint32_t *)data);
+    data += 4;
   }
 
   if (length & 2) {
-    crc = __crc32ch(crc, *(uint16_t *)p);
-    p += 2;
+    crc = __crc32ch(crc, *(uint16_t *)data);
+    data += 2;
   }
 
   if (length & 1) {
-    crc = __crc32cb(crc, *p);
+    crc = __crc32cb(crc, *data);
   }
 
   return crc ^ kCRC32Xor;

--- a/include/crc32c_arm64.h
+++ b/include/crc32c_arm64.h
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-// Linux-specific code checking the availability for ARM CRC32C instructions.
+// ARM-specific code
 
-#ifndef CRC32C_CRC32C_ARM_LINUX_H_
-#define CRC32C_CRC32C_ARM_LINUX_H_
+#ifndef CRC32C_CRC32C_ARM_H_
+#define CRC32C_CRC32C_ARM_H_
 
 #include <cstddef>
 #include <cstdint>
@@ -22,4 +22,4 @@ uint32_t ExtendArm64(uint32_t crc, const uint8_t* data, size_t count);
 
 #endif  // HAVE_ARM64_CRC32C
 
-#endif  // CRC32C_CRC32C_ARM_LINUX_H_
+#endif  // CRC32C_CRC32C_ARM_H_

--- a/include/crc32c_arm64_check.h
+++ b/include/crc32c_arm64_check.h
@@ -2,12 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file. See the AUTHORS file for names of contributors.
 
-// ARM Linux-specific code checking for the availability of CRC32C instructions.
+// ARM-specific code checking for the availability of CRC32C instructions.
 
-#ifndef CRC32C_CRC32C_ARM_LINUX_CHECK_H_
-#define CRC32C_CRC32C_ARM_LINUX_CHECK_H_
-
-// X86-specific code checking for the availability of SSE4.2 instructions.
+#ifndef CRC32C_CRC32C_ARM_CHECK_H_
+#define CRC32C_CRC32C_ARM_CHECK_H_
 
 #include <cstddef>
 #include <cstdint>
@@ -16,6 +14,7 @@
 
 #if HAVE_ARM64_CRC32C
 
+#ifdef __linux__
 #if HAVE_STRONG_GETAUXVAL
 #include <sys/auxv.h>
 #elif HAVE_WEAK_GETAUXVAL
@@ -25,17 +24,36 @@ extern "C" unsigned long getauxval(unsigned long type) __attribute__((weak));
 
 #define AT_HWCAP 16
 #endif  // HAVE_STRONG_GETAUXVAL || HAVE_WEAK_GETAUXVAL
+#endif  // defined (__linux__)
+
+#ifdef __APPLE__
+#include <sys/types.h>
+#include <sys/sysctl.h>
+#endif  // defined (__APPLE__)
 
 namespace crc32c {
 
-inline bool CanUseArm64Linux() {
-#if HAVE_STRONG_GETAUXVAL || HAVE_WEAK_GETAUXVAL
+inline bool CanUseArm64Crc32() {
+#if defined (__linux__) && (HAVE_STRONG_GETAUXVAL || HAVE_WEAK_GETAUXVAL)
   // From 'arch/arm64/include/uapi/asm/hwcap.h' in Linux kernel source code.
   constexpr unsigned long kHWCAP_PMULL = 1 << 4;
   constexpr unsigned long kHWCAP_CRC32 = 1 << 7;
-  unsigned long hwcap = (&getauxval != nullptr) ? getauxval(AT_HWCAP) : 0;
+  unsigned long hwcap =
+#if HAVE_STRONG_GETAUXVAL
+      // Some compilers warn on (&getauxval != nullptr) in the block below.
+      getauxval(AT_HWCAP);
+#elif HAVE_WEAK_GETAUXVAL
+      (&getauxval != nullptr) ? getauxval(AT_HWCAP) : 0;
+#else
+#error This is supposed to be nested inside a check for HAVE_*_GETAUXVAL.
+#endif  // HAVE_STRONG_GETAUXVAL
   return (hwcap & (kHWCAP_PMULL | kHWCAP_CRC32)) ==
          (kHWCAP_PMULL | kHWCAP_CRC32);
+#elif defined(__APPLE__)
+  int val = 0;
+  size_t len = sizeof(val);
+  return sysctlbyname("hw.optional.armv8_crc32", &val, &len, nullptr, 0) == 0
+             && val != 0;
 #else
   return false;
 #endif  // HAVE_STRONG_GETAUXVAL || HAVE_WEAK_GETAUXVAL
@@ -45,4 +63,4 @@ inline bool CanUseArm64Linux() {
 
 #endif  // HAVE_ARM64_CRC32C
 
-#endif  // CRC32C_CRC32C_ARM_LINUX_CHECK_H_
+#endif  // CRC32C_CRC32C_ARM_CHECK_H_

--- a/include/crc32c_read_le.h
+++ b/include/crc32c_read_le.h
@@ -30,14 +30,14 @@ inline uint32_t ReadUint32LE(const uint8_t* buffer) {
 // Reads a little-endian 64-bit integer from a 64-bit-aligned buffer.
 inline uint64_t ReadUint64LE(const uint8_t* buffer) {
 #if BYTE_ORDER_BIG_ENDIAN
-  return ((static_cast<uint32_t>(static_cast<uint8_t>(buffer[0]))) |
-          (static_cast<uint32_t>(static_cast<uint8_t>(buffer[1])) << 8) |
-          (static_cast<uint32_t>(static_cast<uint8_t>(buffer[2])) << 16) |
-          (static_cast<uint32_t>(static_cast<uint8_t>(buffer[3])) << 24) |
-          (static_cast<uint32_t>(static_cast<uint8_t>(buffer[4])) << 32) |
-          (static_cast<uint32_t>(static_cast<uint8_t>(buffer[5])) << 40) |
-          (static_cast<uint32_t>(static_cast<uint8_t>(buffer[6])) << 48) |
-          (static_cast<uint32_t>(static_cast<uint8_t>(buffer[7])) << 56));
+  return ((static_cast<uint64_t>(static_cast<uint8_t>(buffer[0]))) |
+          (static_cast<uint64_t>(static_cast<uint8_t>(buffer[1])) << 8) |
+          (static_cast<uint64_t>(static_cast<uint8_t>(buffer[2])) << 16) |
+          (static_cast<uint64_t>(static_cast<uint8_t>(buffer[3])) << 24) |
+          (static_cast<uint64_t>(static_cast<uint8_t>(buffer[4])) << 32) |
+          (static_cast<uint64_t>(static_cast<uint8_t>(buffer[5])) << 40) |
+          (static_cast<uint64_t>(static_cast<uint8_t>(buffer[6])) << 48) |
+          (static_cast<uint64_t>(static_cast<uint8_t>(buffer[7])) << 56));
 #else   // !BYTE_ORDER_BIG_ENDIAN
   uint64_t result;
   // This should be optimized to a single instruction.

--- a/include/crc32c_sse42.cc
+++ b/include/crc32c_sse42.cc
@@ -174,7 +174,7 @@ uint32_t ExtendSse42(uint32_t crc, const uint8_t* data, size_t size) {
     }
   }
 
-  // Proccess the data in predetermined block sizes with tables for quickly
+  // Process the data in predetermined block sizes with tables for quickly
   // combining the checksum. Experimentally it's better to use larger block
   // sizes where possible so use a hierarchy of decreasing block sizes.
   uint64_t l64 = l;

--- a/package.yaml
+++ b/package.yaml
@@ -47,7 +47,7 @@ tests:
     main: Spec.hs
     dependencies:
     - base >= 4.9 && < 5
-    - bytestring >=0.10.8.2 && <0.11
+    - bytestring >=0.10.8.2 && <0.12
     - crc32c
     - hspec
     - hspec-core

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                crc32c
-version:             0.2.0.0
+version:             0.2.0
 synopsis:            Haskell bindings for crc32c
 # description:
 homepage:            https://github.com/leptonyu/crc32c#readme

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                crc32c
-version:             0.1.0
+version:             0.2.0.0
 synopsis:            Haskell bindings for crc32c
 # description:
 homepage:            https://github.com/leptonyu/crc32c#readme

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,4 @@
-resolver: lts-18.28
+resolver: lts-20.11
+compiler: ghc-9.2.5
 packages:
 - .


### PR DESCRIPTION
Update the native `crc32c` implementation to the latest from upstream. 

- updated the submodule _vendor_ to the latest code from upstream;
- ran the _copy\_cpp.sh_ script;
- bumped the Stackage resolver; and
- loosened the upper bound on **bytestring** for your test case.

